### PR TITLE
Optional force push

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Go to GitLab > Project > Settings > CI/CD Pipelines > Secret Variables, and add 
 -----END RSA PRIVATE KEY-----
 ```
 
+Also add the Secret Variable `STOP_FORCE_PUSH` if you want to disable the default force push to your repository. The if-clause just checks if `STOP_FORCE_PUSH` is empty or not so feel free to add something like `true` as a value.
+
 ### Pushing to a branch other than master
 
 By default, `git-push` will push to branch `master` of a remote repository (that's what Dokku wants). You can override this with:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Go to GitLab > Project > Settings > CI/CD Pipelines > Secret Variables, and add 
 -----END RSA PRIVATE KEY-----
 ```
 
-Also add the Secret Variable `STOP_FORCE_PUSH` if you want to disable the default force push to your repository. The if-clause just checks if `STOP_FORCE_PUSH` is empty or not so feel free to add something like `true` as a value.
+Also add the Secret Variable `SKIP_FORCE_PUSH` if you want to skip the default force push to your repository. The if-clause just checks if `SKIP_FORCE_PUSH` is empty or not so feel free to add something like `true` as a value.
 
 ### Pushing to a branch other than master
 

--- a/git-push
+++ b/git-push
@@ -3,6 +3,7 @@
 url=$1
 branch=$2
 
+
 if [ -z "$SSH_PRIVATE_KEY" ]; then
 	>&2 echo "Set SSH_PRIVATE_KEY environment variable"
 	exit 1
@@ -25,4 +26,10 @@ echo "$SSH_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 ssh-keyscan -H $ssh_port "$ssh_host" >> ~/.ssh/known_hosts
 
-git push $url HEAD:${branch:-master} --force
+# based on the STOP_FORCE_PUSH env variable, disalbe the force push to GitHub
+if [ -z "$STOP_FORCE_PUSH" ]; then
+	git push $url HEAD:${branch:-master} --force
+else
+	>&2 echo "Disabled force push to $2"
+	git push $url HEAD:${branch:-master}
+fi

--- a/git-push
+++ b/git-push
@@ -3,7 +3,6 @@
 url=$1
 branch=$2
 
-
 if [ -z "$SSH_PRIVATE_KEY" ]; then
 	>&2 echo "Set SSH_PRIVATE_KEY environment variable"
 	exit 1

--- a/git-push
+++ b/git-push
@@ -26,10 +26,10 @@ echo "$SSH_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 ssh-keyscan -H $ssh_port "$ssh_host" >> ~/.ssh/known_hosts
 
-# based on the STOP_FORCE_PUSH env variable, disalbe the force push to your configured Git repository
-if [ -z "$STOP_FORCE_PUSH" ]; then
+# based on the SKIP_FORCE_PUSH env variable, disalbe the force push to your configured Git repository
+if [ -z "$SKIP_FORCE_PUSH" ]; then
 	git push $url HEAD:${branch:-master} --force
 else
-	>&2 echo "Disabled force push to $2"
+	>&2 echo "Skipping force push to $2"
 	git push $url HEAD:${branch:-master}
 fi

--- a/git-push
+++ b/git-push
@@ -26,7 +26,7 @@ echo "$SSH_PRIVATE_KEY" | tr -d '\r' > ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 ssh-keyscan -H $ssh_port "$ssh_host" >> ~/.ssh/known_hosts
 
-# based on the STOP_FORCE_PUSH env variable, disalbe the force push to GitHub
+# based on the STOP_FORCE_PUSH env variable, disalbe the force push to your configured Git repository
 if [ -z "$STOP_FORCE_PUSH" ]; then
 	git push $url HEAD:${branch:-master} --force
 else


### PR DESCRIPTION
Hi Ilya, 

we started using your script yesterday and it works as advertised 👍 but we would like to make the force push at the end of your script optional because we have the following use case (but there are certainly others):

We have a lot of repositories on a self-hosted GitLab and some of them should be published to GitHub while still using the GitLab CI for deployment. We currently have to keep working in GitLab because of our CI setup for certain projects. 

And your script is perfect for pushing the master from GitLab to GitHub. But we don't want to force push all the changes because someone might e.g. do a pull request on GitHub, which we might want to in turn push to GitLab BUT if in the meantime someone from our team force pushes to GitHub because they want to deploy stuff, we would lose the changes on GitHub.

For this I have introduced the optional env variable `SKIP_FORCE_PUSH`

Best regards
Nikolay