### PR TITLE
Update Readme and switch to using latest Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.6
 
 RUN apk add --no-cache bash git openssh-client
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:latest
 
 RUN apk add --no-cache bash git openssh-client
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Go to GitLab > Project > Settings > CI/CD > Secret Variables, and add a variable
 -----END RSA PRIVATE KEY-----
 ```
 
-Make sure your private ssh key is not encrypted, or Gitlab won't be able to authenticate. You'll know if it is encrypted if you open it up and the top has something like:
+Make sure your private ssh key is not encrypted, or Gitlab won't be able to authenticate to your SSH server. You'll know if it is encrypted if you open it up and the top has something like:
 
 ```
 -----BEGIN RSA PRIVATE KEY-----

--- a/README.md
+++ b/README.md
@@ -35,15 +35,7 @@ Make sure your private ssh key is not encrypted, or Gitlab won't be able to auth
 Proc-Type: 4,ENCRYPTED
 ```
 
-If it is, generate a new key. You may need to install `openssh-keygen` and then run `ssh-keygen -C my_email` where `my_email` can be any comment. 
-
-You can do this from a docker container running Alpine like this:
-
-```
-apk update && \
-apk add --no-cache \
-openssh-keygen
-```
+If it is, you can decrypt it by running: `openssl rsa -in enc.key -out dec.key`
 
 ### Pushing to a branch other than master
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Go to GitLab > Project > Settings > CI/CD > Secret Variables, and add a variable
 -----END RSA PRIVATE KEY-----
 ```
 
+Make sure your private ssh key is not encrypted, or Gitlab won't be able to authenticate. You'll know if it is encrypted if you open it up and the top has something like:
+
+```
+-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+```
+
+If it is, generate a new key. You may need to install `openssh-keygen` and then run `ssh-keygen -C my_email` where `my_email` can be any comment. 
+
+You can do this from a docker container running Alpine like this:
+
+```
+apk update && \
+apk add --no-cache \
+openssh-keygen
+```
+
 ### Pushing to a branch other than master
 
 By default, `git-push` will push to branch `master` of a remote repository (that's what Dokku wants). You can override this with:


### PR DESCRIPTION
After a long time of searching through random articles, I realized that the ssh key I was using was encrypted. Knowing that little tidbit would have saved me many hours of banging my head against the wall. 